### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,7 +24,7 @@ setADCMode	KEYWORD2
 setPrescalerM	KEYWORD2
 setBatteryCapacity	KEYWORD2
 setBatteryToFull	KEYWORD2
-setRawAccumulatedCharge KEYWORD2
+setRawAccumulatedCharge	KEYWORD2
 setChargeThresholds	KEYWORD2
 setVoltageThresholds	KEYWORD2
 setTemperatureThresholds	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords