### PR TITLE
fix computation of fullRange

### DIFF
--- a/src/LTC2942.cpp
+++ b/src/LTC2942.cpp
@@ -65,7 +65,7 @@ uint16_t LTC2942::getRawAccumulatedCharge() {
 
 float LTC2942::getRemainingCapacity() {
 	uint16_t acr = getRawAccumulatedCharge();
-	float fullRange = 65536 * ((float) _prescalerM / 128) * 0.085;
+	float fullRange = 65536 * ((float) _prescalerM / 128) * 0.085 * ((float) 50 / _rSense);
 	float offset = fullRange - _batteryCapacity;
 	return (acr * ((float) _prescalerM / 128) * 0.085 * ((float) 50 / _rSense)) - offset; // mAh
 }


### PR DESCRIPTION
when using a resistor other than 50 mOhms for rSense the value of fullRange is now computed correctly.

Closes #3 